### PR TITLE
OMNI-4337 

### DIFF
--- a/ui/components/spinners/base/_index.scss
+++ b/ui/components/spinners/base/_index.scss
@@ -39,7 +39,7 @@
  */
 
 .nds-spinner {
-    width: 7rem;
+    width: 4.5rem;
     #{$left}: 50%;
     top: 50%;
     transform: translate(-50%,-50%);

--- a/ui/components/spinners/base/_index.scss
+++ b/ui/components/spinners/base/_index.scss
@@ -263,8 +263,8 @@
  * This is the loading message, specifically for the large spinner
  */
 
-.nds-spinner_large + .vlc-loading-message,
-.nds-spinner--large + .vlc-loading-message,
+.nds-spinner + .vlc-loading-message,
+.nds-spinner + .vlc-loading-message,
 {
   position:absolute;
   top:50%;

--- a/ui/components/spinners/base/_index.scss
+++ b/ui/components/spinners/base/_index.scss
@@ -40,23 +40,24 @@
 
 .nds-spinner {
     width: 7rem;
-    #{$left}: 48%;
-    top: 43%;
+    #{$left}: 50%;
+    top: 50%;
+    transform: translate(-50%,-50%);
     position: absolute;
     svg circle {
       fill: $color-background-spinner-dot;
-      r: 0.5rem;
+      r: 12.5%;
 
       &:nth-child(1) {
-        cx: 0.5rem * 1;
+        cx: 12.5%;
       }
 
       &:nth-child(2) {
-        cx: 0.5rem * 4;
+        cx: 50%;
       }
 
       &:nth-child(3) {
-        cx: 0.5rem * 7;
+        cx: 87.5%;
       }
     }
 }
@@ -118,22 +119,6 @@
 .nds-spinner_xx-small,
 .nds-spinner--xx-small {
   width: 4rem;
-
-  svg circle {
-    r: 0.125rem;
-
-    &:nth-child(1) {
-      cx: 0.125rem * 1;
-    }
-
-    &:nth-child(2) {
-      cx: 0.125rem * 4;
-    }
-
-    &:nth-child(3) {
-      cx: 0.125rem * 7;
-    }
-  }
 }
 
 
@@ -149,23 +134,6 @@
 .nds-spinner_x-small,
 .nds-spinner--x-small {
   width: 4.5rem;
-
-  svg circle {
-    r: 0.25rem;
-
-    &:nth-child(1) {
-      cx: 0.25rem * 1;
-    }
-
-    &:nth-child(2) {
-      cx: 0.25rem * 4;
-    }
-
-    &:nth-child(3) {
-      cx: 0.25rem * 7;
-    }
-  }
-
 }
 
 /**
@@ -180,22 +148,6 @@
 .nds-spinner_small,
 .nds-spinner--small {
   width: 4.5rem;
-
-  svg circle {
-    r: 0.25rem;
-
-    &:nth-child(1) {
-      cx: 0.25rem * 1;
-    }
-
-    &:nth-child(2) {
-      cx: 0.25rem * 4;
-    }
-
-    &:nth-child(3) {
-      cx: 0.25rem * 7;
-    }
-  }
 }
 
 /**
@@ -210,22 +162,6 @@
 .nds-spinner_medium,
 .nds-spinner--medium {
   width: 6rem;
-
-  svg circle {
-    r: 0.5rem;
-
-    &:nth-child(1) {
-      cx: 0.5rem * 1;
-    }
-
-    &:nth-child(2) {
-      cx: 0.5rem * 4;
-    }
-
-    &:nth-child(3) {
-      cx: 0.5rem * 7;
-    }
-  }
 }
 
 /**
@@ -240,23 +176,6 @@
 .nds-spinner_large,
 .nds-spinner--large {
   width: 7rem;
-
-  svg circle {
-    r: 0.625rem;
-
-    &:nth-child(1) {
-      cx: 0.625rem * 1;
-    }
-
-    &:nth-child(2) {
-      cx: 0.625rem * 4;
-    }
-
-    &:nth-child(3) {
-      cx: 0.625rem * 7;
-    }
-  }
-
 }
 
 /**

--- a/ui/components/spinners/base/_index.scss
+++ b/ui/components/spinners/base/_index.scss
@@ -118,7 +118,7 @@
 
 .nds-spinner_xx-small,
 .nds-spinner--xx-small {
-  width: 4rem;
+  width: 1rem;
 }
 
 
@@ -133,7 +133,7 @@
 
 .nds-spinner_x-small,
 .nds-spinner--x-small {
-  width: 4.5rem;
+  width: 1.5rem;
 }
 
 /**
@@ -147,7 +147,7 @@
 
 .nds-spinner_small,
 .nds-spinner--small {
-  width: 4.5rem;
+  width: 2.5rem;
 }
 
 /**
@@ -161,7 +161,7 @@
 
 .nds-spinner_medium,
 .nds-spinner--medium {
-  width: 6rem;
+  width: 4rem;
 }
 
 /**
@@ -175,7 +175,7 @@
 
 .nds-spinner_large,
 .nds-spinner--large {
-  width: 7rem;
+  width: 6rem;
 }
 
 /**

--- a/ui/components/spinners/base/_index.scss
+++ b/ui/components/spinners/base/_index.scss
@@ -258,3 +258,16 @@
   }
 
 }
+
+/**
+ * This is the loading message, specifically for the large spinner
+ */
+
+.nds-spinner_large + .vlc-loading-message,
+.nds-spinner--large + .vlc-loading-message,
+{
+  position:absolute;
+  top:50%;
+  left:50%;
+  transform:translate(-50%,calc(-50% + 2.75rem));
+}


### PR DESCRIPTION
<!--
NOTE: Please make site changes for summer-17/winter-18 directly on the new site's repository.
      Pull requests that don't follow this rule will get closed.
-->

Changes proposed in this pull request:

* Adding styling for loading message to newport
* Redefining positioning for spinner to be responsively centered in stead of hardcoded (was off center)
* Rescaling spinners to approximately match previous configuration. This was done by measuring screencaps and rounding to the nearest half. Small was the same as x small, and bow is set to a size intermediate to x-small and medium. this was done using a line of best fit.

### Reviewer, please refer to this "definition of done" checklist:

* [ ] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
* [ ] Tested on **mobile** (for responsive or mobile-specific features)
* [ ] Confirm **Accessibility**
* [ ] Documentation is up to date
* [ ] Release notes mention the changes

⚠️ Once this pull request is merged, please merge the code into other development branches:
[Merge branch 'spring-17' into summer-17](http://bit.ly/2fjT4LY)
[Merge branch 'summer-17' into winter-18](http://bit.ly/2mbKAbV)
