### PR TITLE
Fixed name for directory that gulp styles puts its output into.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Generate the Lightning Design System into the `.dist` directory.
 
 ### `gulp styles`
 
-Compile Sass to CSS into `.assets/styles`.
+Compile Sass to CSS into `.dist/assets/styles`.
 
 ### `gulp clean`
 


### PR DESCRIPTION
<!--
NOTE: Please make site changes for summer-17/winter-18 directly on the new site's repository.
      Pull requests that don't follow this rule will get closed.
-->

Changes proposed in this pull request:

* Change to Readme to fix directory name affected by gulp styles command.
* No actual coding changes, no impacts beyond readme.

### Reviewer, please refer to this "definition of done" checklist:

* [ ] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
* [ ] Tested on **mobile** (for responsive or mobile-specific features)
* [ ] Confirm **Accessibility**
* [ ] Documentation is up to date
* [ ] Release notes mention the changes

⚠️ Once this pull request is merged, please merge the code into other development branches:
[Merge branch 'spring-17' into summer-17](http://bit.ly/2fjT4LY)
[Merge branch 'summer-17' into winter-18](http://bit.ly/2mbKAbV)
