### PR TITLE
OMNI-4966

### DIFF
--- a/ui/_config.scss
+++ b/ui/_config.scss
@@ -60,3 +60,12 @@ $grid-columns: (1, 2, 3, 4, 5, 6, 7, 8, 12) !default;
 ///
 /// @type String
 $reset-wrapping-class: '.via-nds' !default;
+
+/// Reset wrapping class
+/// Wraps a version of normalize
+///
+/// @example scss
+///  #{$reset-wrapping-class} .foo { ... } // outputs .nds .foo { ... }
+///
+/// @type String
+$reset-wrapping-selector: 'body > *' !default;

--- a/ui/_super-scope.scss
+++ b/ui/_super-scope.scss
@@ -1,0 +1,1 @@
+@import 'components/_super-scope';

--- a/ui/_super-scope.scss
+++ b/ui/_super-scope.scss
@@ -1,1 +1,2 @@
+// this is for styling whose rules require access to second highest element's selector.
 @import 'components/_super-scope';

--- a/ui/components/_super-scope.scss
+++ b/ui/components/_super-scope.scss
@@ -1,0 +1,1 @@
+@import 'knowledge/base/_super-scope';

--- a/ui/components/knowledge/base/_index.scss
+++ b/ui/components/knowledge/base/_index.scss
@@ -10,6 +10,13 @@
  * @required
  * @variant
  */
+.iframeresizer--child & .nds-knowledge-block {
+    position: absolute;
+    .nds-right_panel {
+        height: auto;
+    }
+}
+
 .nds-knowledge-block {
   position: fixed;
   top: 10.625rem;

--- a/ui/components/knowledge/base/_index.scss
+++ b/ui/components/knowledge/base/_index.scss
@@ -10,13 +10,6 @@
  * @required
  * @variant
  */
-.iframeresizer--child & .nds-knowledge-block {
-    position: absolute;
-    .nds-right_panel {
-        height: auto;
-    }
-}
-
 .nds-knowledge-block {
   position: fixed;
   top: 10.625rem;

--- a/ui/components/knowledge/base/_super-scope.scss
+++ b/ui/components/knowledge/base/_super-scope.scss
@@ -1,0 +1,18 @@
+// Copyright (c) 2015-present, salesforce.com, inc. All rights reserved
+// Licensed under BSD 3-Clause - see LICENSE.txt or git.io/sfdc-license
+
+/**
+ * @summary knowledge block fixes
+ *
+ * @name base
+ * @selector .nds-knowledge-block
+ * @restrict div
+ * @required
+ * @variant
+ */
+.iframeresizer--child & .nds-knowledge-block {
+    position: absolute;
+    .nds-right_panel {
+        height: auto;
+    }
+}

--- a/ui/index-scoped.rtl.scss
+++ b/ui/index-scoped.rtl.scss
@@ -30,4 +30,7 @@ $dir: rtl;
 
   // Print
   @import 'vendor/html5boilerplate-print';
+
+  // super-scope hack
+  @import 'super-scope';
 }

--- a/ui/index-scoped.scss
+++ b/ui/index-scoped.scss
@@ -27,4 +27,7 @@
 
   // Print
   @import 'vendor/html5boilerplate-print';
+
+  // super-scope hack
+  @import 'super-scope';
 }

--- a/ui/index.rtl.scss
+++ b/ui/index.rtl.scss
@@ -15,14 +15,17 @@ $dir: rtl;
 @import 'init';
 @import url(./nds-fonts.css);
 
-// Resets
-@import 'vendor/normalize';
-@include core($scoped: false, $globals: true);
+#{$reset-wrapping-selector} {
 
-// Framework
-@import 'touch/index';
-@import 'components/index';
-@import 'utilities/index';
+	// Resets
+	@import 'vendor/normalize';
+	@include core($scoped: false, $globals: true);
 
-// Print
-@import 'vendor/html5boilerplate-print';
+	// Framework
+	@import 'touch/index';
+	@import 'components/index';
+	@import 'utilities/index';
+
+	// Print
+	@import 'vendor/html5boilerplate-print';
+}

--- a/ui/index.rtl.scss
+++ b/ui/index.rtl.scss
@@ -15,17 +15,20 @@ $dir: rtl;
 @import 'init';
 @import url(./nds-fonts.css);
 
+
+// Resets
+@import 'vendor/normalize';
+@include core($scoped: false, $globals: true);
+
+// Framework
+@import 'touch/index';
+@import 'components/index';
+@import 'utilities/index';
+
+// Print
+@import 'vendor/html5boilerplate-print';
+
+// super-scope hack
 #{$reset-wrapping-selector} {
-
-	// Resets
-	@import 'vendor/normalize';
-	@include core($scoped: false, $globals: true);
-
-	// Framework
-	@import 'touch/index';
-	@import 'components/index';
-	@import 'utilities/index';
-
-	// Print
-	@import 'vendor/html5boilerplate-print';
+  @import 'super-scope';
 }

--- a/ui/index.rtl.scss
+++ b/ui/index.rtl.scss
@@ -15,7 +15,6 @@ $dir: rtl;
 @import 'init';
 @import url(./nds-fonts.css);
 
-
 // Resets
 @import 'vendor/normalize';
 @include core($scoped: false, $globals: true);

--- a/ui/index.scss
+++ b/ui/index.scss
@@ -12,17 +12,19 @@
 @import 'init';
 @import url(./nds-fonts.css);
 
+// Resets
+@import 'vendor/normalize';
+@include core($scoped: false, $globals: true);
+
+// Framework
+@import 'touch/index';
+@import 'components/index';
+@import 'utilities/index';
+
+// Print
+@import 'vendor/html5boilerplate-print';
+
+// super-scope hack
 #{$reset-wrapping-selector} {
-
-	// Resets
-	@import 'vendor/normalize';
-	@include core($scoped: false, $globals: true);
-
-	// Framework
-	@import 'touch/index';
-	@import 'components/index';
-	@import 'utilities/index';
-
-	// Print
-	@import 'vendor/html5boilerplate-print';
+	@import 'super-scope';
 }

--- a/ui/index.scss
+++ b/ui/index.scss
@@ -12,14 +12,17 @@
 @import 'init';
 @import url(./nds-fonts.css);
 
-// Resets
-@import 'vendor/normalize';
-@include core($scoped: false, $globals: true);
+#{$reset-wrapping-selector} {
 
-// Framework
-@import 'touch/index';
-@import 'components/index';
-@import 'utilities/index';
+	// Resets
+	@import 'vendor/normalize';
+	@include core($scoped: false, $globals: true);
 
-// Print
-@import 'vendor/html5boilerplate-print';
+	// Framework
+	@import 'touch/index';
+	@import 'components/index';
+	@import 'utilities/index';
+
+	// Print
+	@import 'vendor/html5boilerplate-print';
+}


### PR DESCRIPTION
Adding special handling (with selectors outside of scope) for knowledge sidebar.
using `&` to capture the scoping class.
This unfortunately made it necessary to add a sensical selector for the non-scoped version to represent elements under which any styled elements might be, that is still beneath the `body` element (which is the element with the `.iframeresizer--child` class). For this reason I chose `body > *` to just select the body element's direct children. This bulks up the code a little more than `body *` would, but will help in runtime as its a much simpler rule to apply without overlap cases.

As a side benefit we can now practically import $reset-wrapping-class in all our Resets, Framework, and Print stylesheets on the top level using `&`

<!--
NOTE: Please make site changes for summer-17/winter-18 directly on the new site's repository.
      Pull requests that don't follow this rule will get closed.
-->

Changes proposed in this pull request:

* 
* 
* 

### Reviewer, please refer to this "definition of done" checklist:

* [ ] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
* [ ] Tested on **mobile** (for responsive or mobile-specific features)
* [ ] Confirm **Accessibility**
* [ ] Documentation is up to date
* [ ] Release notes mention the changes

⚠️ Once this pull request is merged, please merge the code into other development branches:
[Merge branch 'spring-17' into summer-17](http://bit.ly/2fjT4LY)
[Merge branch 'summer-17' into winter-18](http://bit.ly/2mbKAbV)
