### PR TITLE
OWC-294 - Added an additional button class for NDS to stretch the button

### DIFF
--- a/ui/components/buttons/base/_index.scss
+++ b/ui/components/buttons/base/_index.scss
@@ -365,3 +365,14 @@ a.nds-button--inverse:focus {
 svg.nds-button__icon {
   fill: $color-input-font-kashmiri-blue;
 }
+
+/**
+ * @summary Creates a button style for 100% width that maintains current styling
+ * @selector .nds-button_stretch
+ * @restrict .nds-button
+ * @modifier
+ * @group size
+ */
+.nds-button_stretch {
+    width: 100%;
+}


### PR DESCRIPTION
<!--
NOTE: Please make site changes for summer-17/winter-18 directly on the new site's repository.
      Pull requests that don't follow this rule will get closed.
-->

Changes proposed in this pull request:

* Added an additional button class for NDS to stretch the button (follows [SLDS rules](https://github.com/salesforce-ux/design-system/blob/master/ui/components/buttons/base/_index.scss)). This change is to fix JIRA ticket (https://vlocity.atlassian.net/browse/OWC-294) for newport.

### Reviewer, please refer to this "definition of done" checklist:

* [ ] Tested on **desktop** (see [supported browsers](https://www.lightningdesignsystem.com/faq/#what-browsers-are-supported))
* [ ] Tested on **mobile** (for responsive or mobile-specific features)
* [ ] Confirm **Accessibility**
* [ ] Documentation is up to date
* [ ] Release notes mention the changes

⚠️ Once this pull request is merged, please merge the code into other development branches:
[Merge branch 'spring-17' into summer-17](http://bit.ly/2fjT4LY)
[Merge branch 'summer-17' into winter-18](http://bit.ly/2mbKAbV)
