### PR TITLE
bug fix for issue-47

### DIFF
--- a/scripts/dist.js
+++ b/scripts/dist.js
@@ -11,7 +11,7 @@ const gulpinsert = require('gulp-insert');
 const gulprename = require('gulp-rename');
 const postcss = require('gulp-postcss');
 const rimraf = require('rimraf');
-const sass = require('gulp-sass');
+const sass = require('gulp-sass')(require('sass'));
 const cleanCSS = require('gulp-clean-css');
 
 const zip = require('gulp-zip');


### PR DESCRIPTION
Hi,

I fixed it by following the errors in the command line.

Looks like the 'gulp-sass' doesn't have a default sass compiler. Hence, had to choose one out of two options
sass and node-sass.

Since we have sass as a dev dependency, I chose to use it as a default sass compiler for gulp-sass.

Now, I am able to build the project.