### PR TITLE
@W-15551913: changed readonly radio button color to light grey color

### DIFF
--- a/ui/design-tokens/_border-color.scss
+++ b/ui/design-tokens/_border-color.scss
@@ -101,7 +101,7 @@ $color-border-botticelli: $newport-border-botticelli !default;
 $color-comment-msz: $newport-color-comment-msz !default;
 $color-dropdown-border: $newport-dropdown-border !default;
 // Accessibility fix for radio group
-$color-background-input-radio-readonly: $palette-gray-20 !default;
+$color-background-input-radio-readonly: $palette-gray-22 !default;
 $color-border-input-radio-readonly: $palette-gray-21 !default;
 //Border color for cancel button
 $color-border-cancel-button: $palette-gray-13 !default;

--- a/ui/variables/_colors.scss
+++ b/ui/variables/_colors.scss
@@ -159,6 +159,7 @@ $palette-gray-12: #2b2826;
 $palette-gray-13: #747474;
 $palette-gray-20:#90939A;
 $palette-gray-21:#908E90;
+$palette-gray-22:#f3f3f3;
 $palette-gray-90: #e5e5e5;
 $palette-warm-gray-1: #fff;
 $palette-warm-gray-2: #fafaf9;


### PR DESCRIPTION
Work item - https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001pGsgBYAS/view
Changed readonly radio button color to light grey so that selected radio button is visible. The color is in consistent with LDS now.